### PR TITLE
fixed sar-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Cons:
 Example:
 
     # Allows access if the user can view the service 'proxy' in namespace 'app-dev'
-    --openshift-sar='{"namespace":"app-dev","resource":"services","name":"proxy","verb":"get"}'
+    --openshift-sar='{"namespace":"app-dev","resource":"services","resourceName":"proxy","verb":"get"}'
 
 A user who visits the proxy will be redirected to an OAuth login with OpenShift, and must grant
 access to the proxy to view their user info and request permissions for them. Once they have granted
@@ -89,7 +89,7 @@ to be able to access the backed server.
 Example:
 
     # Allows access to foo.example.com if the user can view the service 'proxy' in namespace 'app-dev'
-    --openshift-sar-by-host='{"foo.example.com":{"namespace":"app-dev","resource":"services","name":"proxy","verb":"get"}}'
+    --openshift-sar-by-host='{"foo.example.com":{"namespace":"app-dev","resource":"services","resourceName":"proxy","verb":"get"}}'
 
 #### Delegate authentication and authorization to OpenShift for infrastructure
 


### PR DESCRIPTION
Using the provided SubjectAccessReview examples will result in an access denied decision in case the user cannot LIST the given resource-type. As OpenShift looks for a "resourceName" property and not the "name" property it executes a LIST for the resource-type instead of the expected GET on resource-type / resource-name.

https://docs.openshift.com/container-platform/3.11/rest_api/oapi/v1.SubjectAccessReview.html#object-schema